### PR TITLE
Changes in French employee contributions and CSG on pensions

### DIFF
--- a/Stata/do/Extract_from_Lissy.do
+++ b/Stata/do/Extract_from_Lissy.do
@@ -327,9 +327,9 @@ program define FR_tax_CSG_CRDS
   * Labour income
   // CSG and CRDS on labour income is imputed within Employee SSC
   * Capital income
-  gen hic_csg_crds = hic * 0.087 if dname =="fr00"
+  gen hic_csg_crds = hic * 0.08 if dname =="fr00"
   replace hic_csg_crds = hic * 0.087 if dname =="fr05"
-  replace hic_csg_crds = hic * 0.08  if dname =="fr10"
+  replace hic_csg_crds = hic * 0.087  if dname =="fr10"
   * Pensions
     *Family share
     gen N = (nhhmem - nhhmem17)


### PR DESCRIPTION
- I think there was a mistake in the formula that generates employee social contributions directly from net wages: the second term in the first bracket (ee_r1*ee_c1 etc.) should also be divided by 1- marginal rate .
As before, I assume that LIS data is about net income but I am not 100% sure of that point: since LIS receives the data from the French survey Budget des familles, which contains lots of information from fiscal sources, it could be that the income used in BdF (and therefore in LIS) is declared income.
- I think there were several mistakes in the CSG formula on pensions:
   - a small typo (bracket not closed at the right place) => the ceilings were far too high
   - before 2015, the threshold for reduced CSG rate was to pay income taxes (we can use this information, which is simpler)
   - I generate a "pseudo" revenue in the fiscal sense ("revenu fiscal de référence") with a 10 % abatment on income by adding non deductible CSG
   - The value of the threshold for the remaining share above 1 (1759, 1914 etc.) "needs"  to be multiplied by 2 in the formula, because it is added each time there is an additional half share. For example in 2000, if there are 2 shares, then we have the first threshold of 6 584 for the first share and 2*0.5 remaining shares which add 1759 each to the threshold. 
   - As for employee's contributions, one has to divide by 1-rate to find the correct CSG tax base